### PR TITLE
Segfault on failed lock fix

### DIFF
--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -209,7 +209,9 @@ void PushNodeVersion(CNode *pnode, int64_t nTime)
     LogPrintf("send version message: version %d, blocks=%d, us=%s, them=%s, peer=%d\n", PROTOCOL_VERSION, nNodeStartingHeight, addrMe.ToString().c_str(), addrYou.ToString().c_str(), nodeid);
 }
 
-void InitializeNode(CNode *pnode) {
+void InitializeNode(CNode *pnode)
+{
+    LOCK(pnode->cs_vSend);
     CAddress addr = pnode->addr;
     std::string addrName = pnode->addrName;
     NodeId nodeid = pnode->GetId();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1416,9 +1416,11 @@ bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant *grantOu
         return false;
     if (grantOutbound)
         grantOutbound->MoveTo(pnode->grantOutbound);
-    pnode->fNetworkNode = true;
-    InitializeNode(pnode);
-
+    {
+        LOCK(cs_vNodes);
+        pnode->fNetworkNode = true;
+        InitializeNode(pnode);
+    }
 
     return true;
 }


### PR DESCRIPTION
fixes a segfault on a failed lock when initializing a new node and failing to enter critical section cs_vSend